### PR TITLE
Fixed issue that prohibited the copying of some error messages

### DIFF
--- a/src/components/ContractCreation.tsx
+++ b/src/components/ContractCreation.tsx
@@ -82,6 +82,7 @@ const ContractCreation: React.FC<Props> = ({ artifact, contract, setContract, ne
       setContract(newContract)
     } catch (e) {
       alert(e.message)
+      console.log(e.message)
     }
   }
 

--- a/src/components/ContractCreation.tsx
+++ b/src/components/ContractCreation.tsx
@@ -82,7 +82,7 @@ const ContractCreation: React.FC<Props> = ({ artifact, contract, setContract, ne
       setContract(newContract)
     } catch (e) {
       alert(e.message)
-      console.log(e.message)
+      console.error(e.message)
     }
   }
 

--- a/src/components/ContractFunction.tsx
+++ b/src/components/ContractFunction.tsx
@@ -67,8 +67,10 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network }) => {
         .send()
 
       alert(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
+      console.log(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
     } catch (e) {
       alert(e.message)
+      console.log(e.message)
     }
   }
 

--- a/src/components/ContractFunction.tsx
+++ b/src/components/ContractFunction.tsx
@@ -70,7 +70,7 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network }) => {
       console.log(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
     } catch (e) {
       alert(e.message)
-      console.log(e.message)
+      console.error(e.message)
     }
   }
 

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -32,6 +32,7 @@ contract TransferWithTimeout(pubkey sender, pubkey recipient, int timeout) {
       setArtifact(artifact);
     } catch (e) {
       alert(e.message);
+      console.log(e.message);
     }
   }
 

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -32,7 +32,7 @@ contract TransferWithTimeout(pubkey sender, pubkey recipient, int timeout) {
       setArtifact(artifact);
     } catch (e) {
       alert(e.message);
-      console.log(e.message);
+      console.error(e.message);
     }
   }
 


### PR DESCRIPTION
I've come across a roadblock when I got long error messages in the alert box that would prevent me from copying the error.  
This issue has persisted throughout multiple browsers, so I added a line to log the errors to console so that I could copy them, and run the meep debugger.