### PR TITLE
PR to add manual UTXO selection, and persist contract and wallets in local storage

### DIFF
--- a/src/components/ContractCreation.tsx
+++ b/src/components/ContractCreation.tsx
@@ -61,6 +61,7 @@ const ContractCreation: React.FC<Props> = ({ artifact, contract, setContract, ne
     >
       <option>mainnet</option>
       <option>testnet</option>
+      <option>staging</option>
     </Form.Control>
   )
 

--- a/src/components/ContractFunction.tsx
+++ b/src/components/ContractFunction.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
-import { Contract, AbiFunction, Argument, Network, Recipient, SignatureTemplate } from 'cashscript'
+import { Contract, AbiFunction, Argument, Network, Recipient, SignatureTemplate, ElectrumNetworkProvider } from 'cashscript'
 import { Form, InputGroup, Button, Card } from 'react-bootstrap'
-import { readAsType, ExplorerString, Wallet } from './shared'
+import { readAsType, ExplorerString, Wallet, NamedUtxo } from './shared'
 
 interface Props {
   contract?: Contract
@@ -13,12 +13,34 @@ interface Props {
 const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) => {
   const [args, setArgs] = useState<Argument[]>([])
   const [outputs, setOutputs] = useState<Recipient[]>([{ to: '', amount: 0 }])
+  // transaction inputs, not the same as abi.inputs 
+  const [inputs, setInputs] = useState<NamedUtxo[]>([{txid: '', vout: 0, satoshis: 0, name: ``, isP2pkh:false}])
+  const [manualSelection, setManualSelection] = useState<boolean>(false)
+  const [utxoList, setUtxoList] = useState<NamedUtxo[]>([])
 
   useEffect(() => {
     // Set empty strings as default values
     const newArgs = abi?.inputs.map(() => '') || [];
     setArgs(newArgs);
   }, [abi])
+
+  useEffect(() => {
+    if(!manualSelection) return;
+    async function updateUtxos(){
+      if(contract===undefined) return
+      const utxosContract = await contract.getUtxos()
+      console.log(utxosContract)
+      const namedUtxosContract:NamedUtxo[] = utxosContract.map((utxo,index)=> ({ ...utxo, name: `P2SH`, isP2pkh:false }))
+      let newUtxoList= namedUtxosContract
+      for(let i = 0; i < wallets.length; i++){
+        const utxosWallet = await new ElectrumNetworkProvider(network).getUtxos(wallets[i].address);
+        const namedUtxosWallet:NamedUtxo[] = utxosWallet.map(utxo=> ({ ...utxo, name: `P2PKH ${wallets[i].walletName}`, isP2pkh:true, walletIndex:i }))
+        newUtxoList = newUtxoList.concat(namedUtxosWallet)
+      }
+      setUtxoList(newUtxoList);
+    }
+    updateUtxos()
+  }, [manualSelection])
 
   function fillPrivKey(i:number,walletIndex:string) {
     const argsCopy = [...args];
@@ -30,7 +52,17 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
     setArgs(argsCopy);
   }
 
-  const inputFields = abi?.inputs.map((input, i) => (
+  function selectInput(i:number,inputIndex:string) {
+    const inputsCopy = [...inputs];
+    // if no input is selected in select form
+    if(isNaN(Number(inputIndex))) inputsCopy[i] = {txid: '', vout: 0, satoshis: 0, name: ``, isP2pkh:false}
+    else{
+      inputsCopy[i] = utxoList[Number(inputIndex)];
+    }
+    setInputs(inputsCopy);
+  }
+
+  const argumentFields = abi?.inputs.map((input, i) => (
     <InputGroup>
       {input.type==='sig'? (
       <><Form.Control size="sm" id={`${input.name}-parameter-${i}`} disabled
@@ -38,9 +70,9 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
         aria-label={`${input.type} ${input.name}`}
       />
       <Form.Control as="select" size="sm" onChange={event =>fillPrivKey(i,event.target.value)}>
-        <option className="text-center" value={`NaN`}>select wallet</option>
+        <option className="text-center" key={`NaN`} value={`NaN`}>select wallet</option>
         {wallets.map((wallet, walletIndex) => (
-            <option className="text-center" value={`${walletIndex}`}>{wallet.walletName}</option>
+            <option className="text-center" key={`${walletIndex+wallet.walletName}`} value={`${walletIndex}`}>{wallet.walletName}</option>
           ))}
       </Form.Control></>
       ):(
@@ -57,45 +89,81 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
     </InputGroup>
   )) || []
 
-  const receiverInputGroup = outputs.map((output,index) =>(
+  const inputFields = inputs.map((input,i) =>(
     <InputGroup>
       <Form.Control size="sm"
-        placeholder="Receiver address"
-        aria-label="Receiver address"
-        onChange={(event) => {
-          const outputsCopy = [...outputs]
-          const output = outputsCopy[index]
-          output.to = event.target.value
-          outputsCopy[index] = output
-          setOutputs(outputsCopy)
-        }}
+        placeholder={i===0?"contract UTXO":"Add input"}
+        aria-label={i===0?"contract UTXO":"Add input"}
+        disabled
       />
-      <Form.Control size="sm"
-        placeholder="Send amount"
-        aria-label="Send amount"
-        onChange={(event) => {
-          const outputsCopy = [...outputs]
-          const output = outputsCopy[index]
-          output.amount = Number(event.target.value)
-          outputsCopy[index] = output
-          setOutputs(outputsCopy)
-        }}
-      />
+      <Form.Control onChange={event =>selectInput(i,event.target.value)} as="select" size="sm" >
+        <option className="text-center" key='Nan' value={`NaN`}>select UTXO</option>
+        {utxoList.map((utxo, inputIndex) => (
+            <option className="text-center" key={`${inputIndex+utxo.name}`} value={`${inputIndex}`}>{`${utxo.name} ${utxo.satoshis}sats`}</option>
+          ))}
+      </Form.Control>
     </InputGroup>
+  ))
+
+  const outputFields = outputs.map((output,index) =>(
+    <InputGroup>
+    <Form.Control size="sm"
+      placeholder="Receiver address"
+      aria-label="Receiver address"
+      onChange={(event) => {
+        const outputsCopy = [...outputs]
+        const output = outputsCopy[index]
+        output.to = event.target.value
+        outputsCopy[index] = output
+        setOutputs(outputsCopy)
+      }}
+    />
+    <Form.Control size="sm"
+      placeholder="Send amount"
+      aria-label="Send amount"
+      onChange={(event) => {
+        const outputsCopy = [...outputs]
+        const output = outputsCopy[index]
+        output.amount = Number(event.target.value)
+        outputsCopy[index] = output
+        setOutputs(outputsCopy)
+      }}
+    />
+  </InputGroup>
   ))
 
   async function sendTransaction() {
     if (!contract || !abi) return
-    try {
-      const { txid } = await contract.functions[abi.name](...args)
-        .to(outputs)
-        .send()
+    if(!manualSelection){
+      try {
+        const { txid } = await contract.functions[abi.name](...args)
+          .to(outputs)
+          .send()
+  
+        alert(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
+        console.log(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
+      } catch (e) {
+        alert(e.message)
+        console.error(e.message)
+      }
+    } else{
+      try {
+        const contractInputs = inputs.filter(input => !input.isP2pkh)
+        const p2pkhInput = inputs.filter(input => input.isP2pkh)
+        if(p2pkhInput[0].walletIndex===undefined) return
 
-      alert(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
-      console.log(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
-    } catch (e) {
-      alert(e.message)
-      console.error(e.message)
+        const { txid } = await contract.functions[abi.name](...args)
+          .from(contractInputs)
+          .experimentalFromP2PKH(p2pkhInput, new SignatureTemplate(wallets[p2pkhInput[0].walletIndex].privKey))
+          .to(outputs)
+          .send()
+  
+        alert(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
+        console.log(`Transaction successfully sent: ${ExplorerString[network]}/tx/${txid}`)
+      } catch (e) {
+        alert(e.message)
+        console.error(e.message)
+      }
     }
   }
 
@@ -104,11 +172,21 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
     outputsCopy.push({ to: '', amount: 0 })
     setOutputs(outputsCopy)
   }
-
   function removeOutput() {
     const outputsCopy = [...outputs]
     outputsCopy.splice(-1)
     setOutputs(outputsCopy)
+  }
+
+  function addInput() {
+    const inputsCopy = [...inputs]
+    inputsCopy.push({txid: '', vout: 0, satoshis: 0, name: ``, isP2pkh:false })
+    setInputs(inputsCopy)
+  }
+  function removeInput() {
+    const inputsCopy = [...inputs]
+    inputsCopy.splice(-1)
+    setInputs(inputsCopy)
   }
 
   return (
@@ -119,8 +197,27 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
           <Card.Body>
             <Card.Subtitle  style={{ marginBottom: '5px' }}>Arguments</Card.Subtitle>
             <Card.Text>
-              {inputFields}
+              {argumentFields}
             </Card.Text>
+            <Form style={{ marginTop: '10px',marginBottom: '5px' }}>
+              <Form.Check 
+                type="switch"
+                id={abi?.name}
+                label="manual UTXO selection"
+                onChange={()=>setManualSelection(!manualSelection)}
+              />
+            </Form>
+            {manualSelection?(
+              <><Card.Subtitle style={{ marginTop: '10px',marginBottom: '5px' }}>
+                Transaction inputs{' '}
+                <Button variant="outline-secondary" size="sm" disabled={inputs.length<=1} onClick={removeInput}>-</Button>
+                {' '+inputs.length+' '}
+                <Button variant="outline-secondary" size="sm" onClick={addInput}>+</Button>
+              </Card.Subtitle>
+              <Card.Text>
+                {inputFields}
+              </Card.Text></>
+            ):null}
             <Card.Subtitle style={{ marginTop: '10px',marginBottom: '5px' }}>
               Transaction outputs{' '}
               <Button variant="outline-secondary" size="sm" disabled={outputs.length<=1} onClick={removeOutput}>-</Button>
@@ -128,7 +225,7 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
               <Button variant="outline-secondary" size="sm" onClick={addOutput}>+</Button>
             </Card.Subtitle>
             <Card.Text>
-              {receiverInputGroup}
+              {outputFields}
             </Card.Text>
             <Button variant="secondary" size="sm" onClick={sendTransaction}>Send</Button>
           </Card.Body>

--- a/src/components/ContractFunction.tsx
+++ b/src/components/ContractFunction.tsx
@@ -150,11 +150,16 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets }) 
       try {
         const contractInputs = inputs.filter(input => !input.isP2pkh)
         const p2pkhInput = inputs.filter(input => input.isP2pkh)
-        if(p2pkhInput[0].walletIndex===undefined) return
 
-        const { txid } = await contract.functions[abi.name](...args)
+        // check if P2PKH input was added and construct transaction accordingly
+        const { txid } = p2pkhInput[0]!==undefined && p2pkhInput[0].walletIndex!==undefined? 
+          await contract.functions[abi.name](...args)
           .from(contractInputs)
           .experimentalFromP2PKH(p2pkhInput, new SignatureTemplate(wallets[p2pkhInput[0].walletIndex].privKey))
+          .to(outputs)
+          .send()
+        : await contract.functions[abi.name](...args)
+          .from(contractInputs)
           .to(outputs)
           .send()
   

--- a/src/components/ContractFunctions.tsx
+++ b/src/components/ContractFunctions.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const ContractFunctions: React.FC<Props> = ({ artifact, contract, network, wallets }) => {
   const functions = artifact?.abi.map(func => (
-    <ContractFunction contract={contract} abi={func} network={network} wallets={wallets}/>
+    <ContractFunction contract={contract} key={func.name} abi={func} network={network} wallets={wallets}/>
   ))
 
   return (

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -32,11 +32,23 @@ contract TransferWithTimeout(pubkey sender, pubkey recipient, int timeout) {
   const [wallets, setWallets] = useState<Wallet[]>([])
 
   useEffect(() => {
-    compile();
+    const newCode = localStorage.getItem("code");
+    // If the local storage is null
+    if (newCode !== null) {
+      setCode(newCode);
+      try {
+        const artifact = compileString(newCode);
+        setArtifact(artifact);
+      } catch (e) {
+        alert(e.message);
+        console.error(e.message);
+      }
+    }
   }, [])
 
   function compile() {
     try {
+      localStorage.setItem("code", code);
       const artifact = compileString(code);
       setArtifact(artifact);
     } catch (e) {

--- a/src/components/Wallets.tsx
+++ b/src/components/Wallets.tsx
@@ -24,7 +24,11 @@ interface Props {
 
 const WalletInfo: React.FC<Props> = ({network, setShowWallets,  wallets, setWallets, style}) => {
   useEffect(() => {
-    addWallet()
+    const localStorageData = localStorage.getItem("wallets");
+    // If the local storage is null
+    if (localStorageData == null) {
+        addWallet()
+      }
   }, [])
   
   async function addWallet() {
@@ -73,6 +77,45 @@ const WalletInfo: React.FC<Props> = ({network, setShowWallets,  wallets, setWall
     walletsCopy[i].walletName = e.target.value;
     setWallets(walletsCopy)
   };
+
+  useEffect(() => {
+    const readLocalStorage = () => {
+      // Convert the string back to the wallets object
+      const localStorageData = localStorage.getItem("wallets");
+      // If the local storage is not null
+      if (localStorageData !== null) {
+        const newWallets = JSON.parse(localStorageData);
+        setWallets(newWallets);
+      }
+    };
+    // Read local storage on initialization
+    readLocalStorage();
+  }, []);
+
+  useEffect(() => {
+    const readLocalStorage = () => {
+      // Convert the string back to the wallets object
+      const localStorageData = localStorage.getItem("wallets");
+      // If the local storage is not null
+      if (localStorageData !== null) {
+        const newWallets = JSON.parse(localStorageData);
+        for (const wallet of newWallets){
+          wallet.privKey = new Uint8Array(Object.values( wallet.privKey))
+        }
+        setWallets(newWallets);
+      }
+    };
+    // Read local storage on initialization
+    readLocalStorage();
+  }, []);
+
+  useEffect(() => {
+    const writeToLocalStorage = () => {
+      // Clear local storage and write the walletlist array to it as a string
+      localStorage.setItem("wallets", JSON.stringify(wallets));
+    };
+    writeToLocalStorage();
+  }, [wallets]);
 
   const walletList = wallets.map((wallet, index) => (
     <Card style={{ marginBottom: '10px' }} key={wallet.privKeyHex}>

--- a/src/components/shared/index.tsx
+++ b/src/components/shared/index.tsx
@@ -60,6 +60,6 @@ export function readAsType(value: string, type: string) {
 export const ExplorerString = {
   mainnet: 'https://explorer.bitcoin.com/bch',
   testnet: 'http://testnet.imaginary.cash',
-  staging: 'https://testnet4.imaginary.cash/',
+  staging: 'https://testnet4.imaginary.cash',
   regtest: ''
 }

--- a/src/components/shared/index.tsx
+++ b/src/components/shared/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { SignatureTemplate } from 'cashscript';
+import { SignatureTemplate, Utxo } from 'cashscript';
 import { decodeCashAddress, decodeCashAddressFormatWithoutPrefix } from '@bitauth/libauth';
 
 export const ColumnFlex = styled.div`
@@ -19,6 +19,12 @@ export interface Wallet {
   pubKeyHashHex: string
   address: string
   testnetAddress: string
+}
+
+export interface NamedUtxo extends Utxo {
+  name: string;
+  isP2pkh: boolean;
+  walletIndex?: number;
 }
 
 export function readAsType(value: string, type: string) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -46,6 +46,10 @@ code {
 .btn-outline-secondary{
   padding: 2px 6px;
 }
+.custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #d848af;
+  border-color: #ea4cbd;
+}
 
 .App {
   min-height: 100vh;


### PR DESCRIPTION
The first commit adds a slider to enable manual UTXO selection.  This might be handy even when working with multiple P2SH outputs if you just want to control inputs but more importantly it adds the ability to easily add a P2PKH input together with a smart contract input. So it allows for testing/using covenant functions that require the balance of the contract to grow or which place restrictions on the input.

A drawback is that the current setup only allows for one P2PKH input because of .experimentalFromP2PKH() works.

The second commit stores the contract code and wallet list (including names) in localstorage. It does not yet store contract arguments. It also adds "staging" to the dropdown list of networks.

live version of the changes at https://cashscript-playground.netlify.app/
UTXO selection certainly works but might have to test edgecases more like muliple P2PKH inputs or no P2SH inputs...